### PR TITLE
Fix override specifier errors

### DIFF
--- a/src/main/slice_translator/coordinates_translator.h
+++ b/src/main/slice_translator/coordinates_translator.h
@@ -16,10 +16,10 @@ class CoordinatesTranslator : public scanner_client::ScannerObserver {
   // ScannerObserver
   void OnScannerStarted(bool success) override {};
   void OnScannerStopped(bool success) override {};
-  void OnScannerDataUpdate(const lpcs::Slice& data, const macs::Point& axis_position) override;
+  void OnScannerDataUpdate(const lpcs::Slice& data, const macs::Point& axis_position);
+  void OnScannerDataUpdateV2(const lpcs::Slice& data, const macs::Point& axis_position) override;
 
  private:
-  void OnScannerDataUpdateV2(const lpcs::Slice& data, const macs::Point& axis_position);
 
   SliceTranslatorService* slice_translator_;
   SliceTranslatorServiceV2* slice_translator_v2_;


### PR DESCRIPTION
Correct `override` specifiers for scanner data update methods to resolve compilation errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-94969691-fc29-434e-9b86-a1ce5654253b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-94969691-fc29-434e-9b86-a1ce5654253b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

