### PR TITLE
Test joint tracking configuration failure

### DIFF
--- a/src/configuration/config_manager.cc
+++ b/src/configuration/config_manager.cc
@@ -156,7 +156,8 @@ auto ConfigManager::ReadConfigurationFile(const fs::path& config_file, bool must
   for (auto& config : config_map) {
     // Key is "configuration/<tag>", extract tag
     auto key       = config.first;
-    const auto tag = key.substr(key.find('/') + 1, key.length() - 1);
+    const auto pos = key.find('/');
+    const auto tag = pos == std::string::npos ? key : key.substr(pos + 1);
 
     if (!converters_.contains(tag)) {
       LOG_TRACE("Configuration tag does not exist: {}", tag);

--- a/src/configuration/config_manager_impl.cc
+++ b/src/configuration/config_manager_impl.cc
@@ -156,7 +156,8 @@ auto ConfigManagerImpl::ReadConfigurationFile(const fs::path& config_file, bool 
   for (auto& config : config_map) {
     // Key is "configuration/<tag>", extract tag
     auto key       = config.first;
-    const auto tag = key.substr(key.find('/') + 1, key.length() - 1);
+    const auto pos = key.find('/');
+    const auto tag = pos == std::string::npos ? key : key.substr(pos + 1);
 
     if (!converters_.contains(tag)) {
       LOG_TRACE("Configuration tag does not exist: {}", tag);


### PR DESCRIPTION
Fix config tag extraction to correctly resolve sub-configuration file paths.

---
<a href="https://cursor.com/background-agent?bcId=bc-e20d28c1-b251-4721-9772-291c89f1fa91">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e20d28c1-b251-4721-9772-291c89f1fa91">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

