### PR TITLE
Add joint characteristics to metrics

### DIFF
--- a/docs/WebHMI_Interface_Description.md
+++ b/docs/WebHMI_Interface_Description.md
@@ -307,6 +307,21 @@ Horizontal and vertical position (in mm)
 {"name":"GetSlidesPositionRsp","payload":{"horizontal":5.0,"vertical":10.0}}
 ```
 
+## Joint Characteristics (Metrics)
+
+Joint characteristics derived from the ABW points are exported as Prometheus gauges under the metric family
+`adaptio_joint_characteristic{name="<metric>"}`. These update continuously during tracking and can be visualized in the Adaptio dashboard.
+
+- `top_width_mm`: distance between ABW0 and ABW6 along horizontal (mm)
+- `bottom_width_mm`: distance between ABW1 and ABW5 along horizontal (mm)
+- `left_depth_mm`: vertical delta between ABW0 and ABW1 (mm)
+- `right_depth_mm`: vertical delta between ABW6 and ABW5 (mm)
+- `avg_depth_mm`: mean of left/right depth (mm)
+- `top_edge_vertical_diff_mm`: ABW0.vertical - ABW6.vertical (mm)
+- `area_mm2`: polygon area of groove (mm^2)
+- `left_wall_angle_rad`: left wall angle (rad)
+- `right_wall_angle_rad`: right wall angle (rad)
+
 ## ServiceModeTracking
 
 Joint tracking can be started as a service mode function. This is mainly for test purposes.

--- a/src/block_tests/metrics_test.cc
+++ b/src/block_tests/metrics_test.cc
@@ -25,13 +25,17 @@ TEST_SUITE("Metrics") {
     // Collect metrics and check counter
     auto collected = fixture.Sut()->Registry()->Collect();
     double laser_torch_calibration_start_count{};
+    bool found_joint_characteristics_family = false;
     for (auto const& metric_family : collected) {
       if (metric_family.name == "adaptio_laser_torch_calibration_starts_total") {
         laser_torch_calibration_start_count = metric_family.metric[0].counter.value;
-        break;
+      }
+      if (metric_family.name == "adaptio_joint_characteristic") {
+        found_joint_characteristics_family = true;
       }
     }
     CHECK_EQ(1.0, laser_torch_calibration_start_count);
+    CHECK(found_joint_characteristics_family);
   }
 }
 // NOLINTEND(*-magic-numbers, *-optional-access, hicpp-signed-bitwise)

--- a/src/main/application.cc
+++ b/src/main/application.cc
@@ -116,7 +116,8 @@ auto Application::Run(const std::string& event_loop_name, const std::string& end
   // Service Mode
   web_hmi_server_ = std::make_unique<web_hmi::WebHmiServer>(web_hmi_in_socket_.get(), web_hmi_out_socket_.get(),
                                                             joint_geometry_provider_.get(),
-                                                            kinematics_client_.get(), activity_status_.get());
+                                                            kinematics_client_.get(), activity_status_.get(),
+                                                            registry_);
 
   // Image logging manager
   auto image_logger_config = configuration_->GetImageLoggingConfiguration();


### PR DESCRIPTION
Add Prometheus gauges for joint width, depth, area, and angles to enable their visualization in the Adaptio dashboard.

---
<a href="https://cursor.com/background-agent?bcId=bc-733ec563-3bf3-4e00-9a03-3f8e7ef28a3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-733ec563-3bf3-4e00-9a03-3f8e7ef28a3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

